### PR TITLE
Remove requirements status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 [![Build Status](https://travis-ci.com/IQTLabs/pypi-scan.svg?branch=master)](https://travis-ci.com/IQTLabs/pypi-scan)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/d1731169a12d42da81da02b249ca069c)](https://www.codacy.com/manual/jmeyers/pypi-scan?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=jspeed-meyers/pypi-scan&amp;utm_campaign=Badge_Grade)
 [![codecov](https://codecov.io/gh/IQTLabs/pypi-scan/branch/master/graph/badge.svg)](https://codecov.io/gh/IQTLabs/pypi-scan)
-[![Requirements Status](https://requires.io/github/IQTLabs/pypi-scan/requirements.svg?branch=master)](https://requires.io/github/IQTLabs/pypi-scan/requirements/?branch=master)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/4133/badge)](https://bestpractices.coreinfrastructure.org/projects/4133)
 [![Documentation Status](https://readthedocs.org/projects/pypi-scan/badge/?version=latest)](https://pypi-scan.readthedocs.io/en/latest/?badge=latest)
 [![Python 3.7](https://img.shields.io/badge/python-3.7-blue.svg)](https://www.python.org/downloads/release/python-360/)


### PR DESCRIPTION
The requirements status badge always shows out of date despite my updating dependencies. I am removing this badge until I better understand how to use requires.io and the accompanying badge.